### PR TITLE
Compatibility update to 1.20

### DIFF
--- a/data/enchantplus/advancements/big_path.json
+++ b/data/enchantplus/advancements/big_path.json
@@ -3,9 +3,14 @@
     "requirement": {
       "trigger": "minecraft:item_used_on_block",
       "conditions": {
-        "item": {
-          "nbt": "{CustomEnchantments:[{id:\"BigPath\"}]}"
-        }
+        "location": [
+          {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "nbt": "{CustomEnchantments:[{id:\"BigPath\"}]}"
+            }
+          }
+        ]
       }
     }
   },

--- a/data/enchantplus/advancements/grand_tilling.json
+++ b/data/enchantplus/advancements/grand_tilling.json
@@ -3,9 +3,14 @@
     "requirement": {
       "trigger": "minecraft:item_used_on_block",
       "conditions": {
-        "item": {
-          "nbt": "{CustomEnchantments:[{id:\"GrandTilling\"}]}"
-        }
+        "location": [
+          {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "nbt": "{CustomEnchantments:[{id:\"GrandTilling\"}]}"
+            }
+          }
+        ]
       }
     }
   },

--- a/data/enchantplus/advancements/placed_charged_bookshelf.json
+++ b/data/enchantplus/advancements/placed_charged_bookshelf.json
@@ -3,10 +3,17 @@
     "requirement": {
       "trigger": "minecraft:placed_block",
       "conditions": {
-        "block": "minecraft:bookshelf",
-        "item": {
-          "nbt": "{TeplusChBf:1b}"
-        }
+        "location": [
+          {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "items": [
+                "minecraft:bookshelf"
+              ],
+              "nbt": "{TeplusChBf:1b}"
+            }
+          }
+        ]
       }
     }
   },

--- a/data/enchantplus/advancements/placed_enchanting_table.json
+++ b/data/enchantplus/advancements/placed_enchanting_table.json
@@ -3,7 +3,16 @@
     "requirement": {
       "trigger": "minecraft:placed_block",
       "conditions": {
-        "block": "minecraft:enchanting_table"
+        "location": [
+          {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "items": [
+                "minecraft:enchanting_table"
+              ]
+            }
+          }
+        ]
       }
     }
   },

--- a/data/enchantplus/advancements/progress/root.json
+++ b/data/enchantplus/advancements/progress/root.json
@@ -21,7 +21,16 @@
     "requirement": {
       "trigger": "minecraft:placed_block",
       "conditions": {
-        "block": "minecraft:enchanting_table"
+        "location": [
+          {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "items": [
+                "minecraft:enchanting_table"
+              ]
+            }
+          }
+        ]
       }
     }
   }

--- a/data/enchantplus/predicates/enchanted_horse.json
+++ b/data/enchantplus/predicates/enchanted_horse.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/data/enchantplus/predicates/has_ench/boots.json
+++ b/data/enchantplus/predicates/has_ench/boots.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/data/enchantplus/predicates/has_ench/chestplate.json
+++ b/data/enchantplus/predicates/has_ench/chestplate.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/data/enchantplus/predicates/has_ench/general.json
+++ b/data/enchantplus/predicates/has_ench/general.json
@@ -1,5 +1,5 @@
 {
-	"condition": "minecraft:alternative",
+	"condition": "minecraft:any_of",
 	"terms": [
 	  {
 		"condition": "minecraft:reference",

--- a/data/enchantplus/predicates/has_ench/helmet.json
+++ b/data/enchantplus/predicates/has_ench/helmet.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/data/enchantplus/predicates/has_ench/leggings.json
+++ b/data/enchantplus/predicates/has_ench/leggings.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/data/enchantplus/predicates/has_ench/offhand.json
+++ b/data/enchantplus/predicates/has_ench/offhand.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/data/enchantplus/predicates/has_ench/selected.json
+++ b/data/enchantplus/predicates/has_ench/selected.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/data/enchantplus/predicates/has_fear.json
+++ b/data/enchantplus/predicates/has_fear.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/data/enchantplus/predicates/none_ench.json
+++ b/data/enchantplus/predicates/none_ench.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/data/technical_anvil/advancements/placed.json
+++ b/data/technical_anvil/advancements/placed.json
@@ -1,18 +1,24 @@
 {
 	"criteria": {
-		"requirement": {
-			"trigger": "minecraft:placed_block",
-			"conditions": {
-				"item": {
-					"items": [
-						"minecraft:player_head"
-					],
-					"nbt": "{Teplus.anvil:1b}"
-				}
+	  "requirement": {
+		"trigger": "minecraft:placed_block",
+		"conditions": {
+		  "location": [
+			{
+			  "condition": "minecraft:match_tool",
+			  "predicate": {
+				"items": [
+				  "minecraft:player_head"
+				],
+				"nbt": "{Teplus.anvil:1b}"
+			  }
 			}
+		  ]
 		}
+	  }
 	},
 	"rewards": {
-		"function": "technical_anvil:place/init"
+	  "function": "technical_anvil:place/init"
 	}
 }
+  

--- a/data/teplus_admin_box/advancements/placed_admin_box.json
+++ b/data/teplus_admin_box/advancements/placed_admin_box.json
@@ -1,18 +1,24 @@
 {
 	"criteria": {
 		"requirement": {
-			"trigger": "minecraft:placed_block",
-			"conditions": {
-				"item": {
-					"items": [
-						"minecraft:player_head"
-					],
-					"nbt": "{TeplusAdminBox:1b}"
+		"trigger": "minecraft:placed_block",
+		"conditions": {
+			"location": [
+			{
+				"condition": "minecraft:match_tool",
+				"predicate": {
+				"items": [
+					"minecraft:player_head"
+				],
+				"nbt": "{TeplusAdminBox:1b}"
 				}
 			}
+			]
+		}
 		}
 	},
 	"rewards": {
 		"function": "teplus_admin_box:events/placed/init"
 	}
 }
+  

--- a/data/teplus_exten/advancements/place_custom_head.json
+++ b/data/teplus_exten/advancements/place_custom_head.json
@@ -3,34 +3,49 @@
     "isolated_core": {
       "trigger": "minecraft:placed_block",
       "conditions": {
-        "item": {
-          "items": [
-            "minecraft:player_head"
-          ],
-          "nbt": "{TeplusHead:{isolated_core:1b}}"
-        }
+        "location": [
+          {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "items": [
+                "minecraft:player_head"
+              ],
+              "nbt": "{TeplusHead:{isolated_core:1b}}"
+            }
+          }
+        ]
       }
     },
     "polished_lapis": {
       "trigger": "minecraft:placed_block",
       "conditions": {
-        "item": {
-          "items": [
-            "minecraft:player_head"
-          ],
-          "nbt": "{TeplusHead:{polished_lapis:1b}}"
-        }
+        "location": [
+          {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "items": [
+                "minecraft:player_head"
+              ],
+              "nbt": "{TeplusHead:{polished_lapis:1b}}"
+            }
+          }
+        ]
       }
     },
     "blessed_orb": {
       "trigger": "minecraft:placed_block",
       "conditions": {
-        "item": {
-          "items": [
-            "minecraft:player_head"
-          ],
-          "nbt": "{TeplusHead:{blessed_orb:1b}}"
-        }
+        "location": [
+          {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "items": [
+                "minecraft:player_head"
+              ],
+              "nbt": "{TeplusHead:{blessed_orb:1b}}"
+            }
+          }
+        ]
       }
     }
   },

--- a/data/teplus_exten/item_modifiers/spawn/set_lore/anti_knockback1.json
+++ b/data/teplus_exten/item_modifiers/spawn/set_lore/anti_knockback1.json
@@ -20,7 +20,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",

--- a/data/teplus_exten/item_modifiers/spawn/set_lore/anti_knockback2.json
+++ b/data/teplus_exten/item_modifiers/spawn/set_lore/anti_knockback2.json
@@ -20,7 +20,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",

--- a/data/teplus_exten/item_modifiers/spawn/set_lore/attack_speed1.json
+++ b/data/teplus_exten/item_modifiers/spawn/set_lore/attack_speed1.json
@@ -19,7 +19,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",
@@ -71,7 +71,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",
@@ -123,7 +123,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",
@@ -175,7 +175,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",
@@ -227,7 +227,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",
@@ -281,7 +281,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",

--- a/data/teplus_exten/item_modifiers/spawn/set_lore/attack_speed2.json
+++ b/data/teplus_exten/item_modifiers/spawn/set_lore/attack_speed2.json
@@ -19,7 +19,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",
@@ -71,7 +71,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",
@@ -123,7 +123,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",
@@ -175,7 +175,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",
@@ -227,7 +227,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",
@@ -281,7 +281,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",

--- a/data/teplus_exten/item_modifiers/spawn/set_lore/attack_speed3.json
+++ b/data/teplus_exten/item_modifiers/spawn/set_lore/attack_speed3.json
@@ -19,7 +19,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",
@@ -71,7 +71,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",
@@ -123,7 +123,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",
@@ -175,7 +175,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",
@@ -227,7 +227,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",
@@ -281,7 +281,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",

--- a/data/teplus_exten/item_modifiers/spawn/set_lore/hardness_plus1.json
+++ b/data/teplus_exten/item_modifiers/spawn/set_lore/hardness_plus1.json
@@ -19,7 +19,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",

--- a/data/teplus_exten/item_modifiers/spawn/set_lore/hardness_plus2.json
+++ b/data/teplus_exten/item_modifiers/spawn/set_lore/hardness_plus2.json
@@ -19,7 +19,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",

--- a/data/teplus_exten/item_modifiers/spawn/set_lore/hardness_plus3.json
+++ b/data/teplus_exten/item_modifiers/spawn/set_lore/hardness_plus3.json
@@ -19,7 +19,7 @@
     ],
     "conditions": [
       {
-        "condition": "minecraft:alternative",
+        "condition": "minecraft:any_of",
         "terms": [
           {
             "condition": "minecraft:entity_properties",

--- a/data/teplus_exten/predicates/drops/has_attributes.json
+++ b/data/teplus_exten/predicates/drops/has_attributes.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/data/teplus_exten/predicates/drops/has_effects.json
+++ b/data/teplus_exten/predicates/drops/has_effects.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/data/teplus_exten/predicates/mobs/has_general.json
+++ b/data/teplus_exten/predicates/mobs/has_general.json
@@ -1,5 +1,5 @@
 {
-	"condition": "minecraft:alternative",
+	"condition": "minecraft:any_of",
 	"terms": [
 		{
 			"condition": "minecraft:entity_properties",

--- a/data/teplus_exten/predicates/mobs/wear_armor.json
+++ b/data/teplus_exten/predicates/mobs/wear_armor.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/data/teplus_exten/predicates/mobs/wear_sensitive.json
+++ b/data/teplus_exten/predicates/mobs/wear_sensitive.json
@@ -1,5 +1,5 @@
 {
-	"condition": "minecraft:alternative",
+	"condition": "minecraft:any_of",
 	"terms": [
     {
 			"condition": "minecraft:entity_properties",

--- a/data/teplus_exten/predicates/villagers/can_discount.json
+++ b/data/teplus_exten/predicates/villagers/can_discount.json
@@ -1,5 +1,5 @@
 {
-	"condition": "minecraft:alternative",
+	"condition": "minecraft:any_of",
 	"terms": [
 	  {
 		

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,7 +1,7 @@
 {
 	"pack":
 	{
-		"pack_format": 12,
+		"pack_format": 15,
 		"description": [
             {
                 "text": "by ",
@@ -20,7 +20,7 @@
                 "color": "#CF130C"
             },
             {
-                "text": "→ 1.19.4",
+                "text": "→ 1.20",
                 "color": "#DB9E4F"
             }
         ]


### PR DESCRIPTION
### Purpose of Change
[Very few changes for data packs in 1.20](https://minecraft.fandom.com/wiki/Category:Java_Edition_1.20_snapshots) that this one has to worry about...
As of [23w18a](https://minecraft.fandom.com/wiki/Java_Edition_23w18a) a few changes that are notable for this data pack to be updated changed:
1. All fields in placed_block and item_used_on_block advancement triggers have been collapsed to a single location field
2. Condition alternative has been renamed to any_of
3. The data pack version is now 15, accounting for predicate/loot table and advancement changes.

### Manual Testing Steps
- [x] Check that server log on load says 1.20
- [x] Check Big Path still works
- [x] Check Grand Tilling still works
- [x] Place an enchanting table, you should get the advancement, and the table should work as expected
- [x] Place a charged book shelf 
- [x] Check that placing a technical anvil still works
- [x] Check that placing an admin box still works
- [x] Should be able to place isolated cores, polished lapis, and blessed orbs and have them work